### PR TITLE
Add info on disabling progression to FAQ

### DIFF
--- a/docs/intel/faq.md
+++ b/docs/intel/faq.md
@@ -52,6 +52,7 @@ title: Frequently Asked Questions
 ### Missing Items / Maps
 
 -   Starting from v6, Peacock should be able to automatically detect when you obtain a new DLC, and give you access to those new items / maps
+-   Version 6.1.0 introduced progression to peacock, meaning you now can unlock items as you play. This is enabled by default, to emulate the experience of the official servers. To disable this set `enableMasteryProgression` in `options.ini` to `false`.
 
 ### Other
 
@@ -79,7 +80,7 @@ title: Frequently Asked Questions
 ## How Peacock Works FAQ
 
 -   See [What is Peacock](./what-is-peacock.md)
-    -   See above link for questions on progression (challenges and mastery etc), Freelancer integration with Peacock, whether or not you need Internet to use Peacock, or any other general questions on how Peacock works
+    -   See above link for questions on Freelancer integration with Peacock, whether or not you need Internet to use Peacock, or any other general questions on how Peacock works
 
 ## Feature Request FAQ
 

--- a/docs/intel/faq.md
+++ b/docs/intel/faq.md
@@ -52,7 +52,7 @@ title: Frequently Asked Questions
 ### Missing Items / Maps
 
 -   Starting from v6, Peacock should be able to automatically detect when you obtain a new DLC, and give you access to those new items / maps
--   Version 6.1.0 introduced progression to peacock, meaning you now can unlock items as you play. This is enabled by default, to emulate the experience of the official servers. To disable this set `enableMasteryProgression` in `options.ini` to `false`.
+-   v6.1.0 introduced progression to peacock, meaning you now can unlock items as you play. This is enabled by default, to emulate the experience of the official servers. To disable this set `enableMasteryProgression` in `options.ini` to `false`.
 
 ### Other
 


### PR DESCRIPTION
This was previously only mentioned in the What-Is-Peacock page.