### PR TITLE
Fix outdated plugin install instructions

### DIFF
--- a/docs/custom-content.md
+++ b/docs/custom-content.md
@@ -70,7 +70,7 @@ Peacock supports a broad variety of server side mods (plugins). These include, b
 ### How to Install Plugins
 
 -   Broadly speaking, to install plugins, go to either the `plugins` or `#plugin-releases` channel in the Peacock Discord and download a plugin you are interested in.
--   Create a folder named `plugins` in the peacock folder, and then put your plugins there.
+-   -   Put your plugins into the `plugins` folder in the peacock folder.
     -   Example: ![PluginsFolder](/img/plugins_folder.png)
 -   Be sure to check for any further instructions in the `#plugin-releases` channel for a given plugin, as certain plugins may require further installation steps or are incompatible with newer versions of Peacock.
 

--- a/docs/custom-content.md
+++ b/docs/custom-content.md
@@ -70,8 +70,7 @@ Peacock supports a broad variety of server side mods (plugins). These include, b
 ### How to Install Plugins
 
 -   Broadly speaking, to install plugins, go to either the `plugins` or `#plugin-releases` channel in the Peacock Discord and download a plugin you are interested in.
--   Then, install it to the same folder that `Start Server.cmd` and `peacockpatcher.exe` are in.
--   Alternatively, create a folder named `plugins`, and then put your plugins there, to organize your files better.
+-   Create a folder named `plugins` in the peacock folder, and then put your plugins there.
     -   Example: ![PluginsFolder](/img/plugins_folder.png)
 -   Be sure to check for any further instructions in the `#plugin-releases` channel for a given plugin, as certain plugins may require further installation steps or are incompatible with newer versions of Peacock.
 

--- a/docs/custom-content.md
+++ b/docs/custom-content.md
@@ -70,7 +70,7 @@ Peacock supports a broad variety of server side mods (plugins). These include, b
 ### How to Install Plugins
 
 -   Broadly speaking, to install plugins, go to either the `plugins` or `#plugin-releases` channel in the Peacock Discord and download a plugin you are interested in.
--   -   Put your plugins into the `plugins` folder in the peacock folder.
+-   -   Put your plugins into the `plugins` folder in the Peacock folder.
     -   Example: ![PluginsFolder](/img/plugins_folder.png)
 -   Be sure to check for any further instructions in the `#plugin-releases` channel for a given plugin, as certain plugins may require further installation steps or are incompatible with newer versions of Peacock.
 


### PR DESCRIPTION
Installing plugins into the peacock folder directly is deprecated, so it should be removed from the wiki.