### PR TITLE
Improved readability of features image

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -27,6 +27,8 @@
 .featureImage {
     height: 200px;
     width: 200px;
+    background-color: white;
+    border-radius: 20px;
 }
 
 .cardSpace {


### PR DESCRIPTION
Quick fix:
Added a background to the features image in order to improve readability using dark mode.

This background could be added to the entire features section to make it more coherent but most optimal would be to change the color of the SVG when in dark mode to the proper font color


![image](https://github.com/user-attachments/assets/39698ef3-4094-409b-8d05-565e869dfa5e)
